### PR TITLE
Fix: fix lambda remove 404 error

### DIFF
--- a/cli/internal/command/lambda/remove.go
+++ b/cli/internal/command/lambda/remove.go
@@ -3,6 +3,7 @@ package lambda
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 
 	"github.com/57blocks/auto-action/cli/internal/config"
 	"github.com/57blocks/auto-action/cli/internal/pkg/errorx"
@@ -41,7 +42,7 @@ func removeFunc(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	URL := util.ParseReqPath(fmt.Sprintf("%s/lambda/%s", config.Vp.GetString("bound_with.endpoint"), args[0]))
+	URL := util.ParseReqPath(fmt.Sprintf("%s/lambda/%s", config.Vp.GetString("bound_with.endpoint"), url.PathEscape(args[0])))
 
 	response, err := restyx.Client.R().
 		EnableTrace().


### PR DESCRIPTION
When remove the lambda name suck like `onetime-demo` will error 404.